### PR TITLE
v0.2.5: Catch up with Rust SDK v0.2.8; rename set, get; fix instant server ver

### DIFF
--- a/colink/colink.py
+++ b/colink/colink.py
@@ -73,11 +73,15 @@ class CoLink:
         remote_storage_delete,
     )
     from .variable_transfer import (
-        set_variable_with_remote_storage,
-        get_variable_with_remote_storage,
-        set_variable,
-        get_variable,
+        send_variable_with_remote_storage,
+        recv_variable_with_remote_storage,
+        send_variable,
+        recv_variable,
     )
+    set_variable_with_remote_storage = send_variable_with_remote_storage
+    get_variable_with_remote_storage = recv_variable_with_remote_storage
+    set_variable = send_variable
+    get_variable = recv_variable
     from .participant_id import get_participant_index
     from .registry import update_registries
     from .lock_key import lock, lock_with_retry_time, unlock

--- a/colink/colink.py
+++ b/colink/colink.py
@@ -58,6 +58,8 @@ class CoLink:
         get_user_id,
         start_protocol_operator,
         stop_protocol_operator,
+        generate_token_with_signature,
+        get_core_addr,
     )
     from .policy_module import (
         policy_module_start,
@@ -78,6 +80,7 @@ class CoLink:
         send_variable,
         recv_variable,
     )
+
     set_variable_with_remote_storage = send_variable_with_remote_storage
     get_variable_with_remote_storage = recv_variable_with_remote_storage
     set_variable = send_variable

--- a/colink/instant_server.py
+++ b/colink/instant_server.py
@@ -7,6 +7,8 @@ import random
 import time
 import socket
 import atexit
+import requests
+import pika
 from colink import CoLink
 
 
@@ -41,6 +43,16 @@ class InstantServer:
         mq_api = os.environ.get(
             "COLINK_SERVER_MQ_API", "http://guest:guest@localhost:15672/api"
         )
+        response = requests.get(mq_api)
+        STATUS_OK = 200
+        assert response.status_code == STATUS_OK, "MQ_API connection failed"
+        parameters = pika.URLParameters(mq_amqp)
+        try:
+            connection = pika.BlockingConnection(parameters)
+            assert connection.is_open, "MQ_AMQP connection failed"
+            connection.close()
+        except Exception as error:
+            raise error
         self.process = subprocess.Popen(
             [
                 program,

--- a/colink/instant_server.py
+++ b/colink/instant_server.py
@@ -71,9 +71,7 @@ class InstantServer:
                 "--inter-core-reverse-mode",
             ],
             env={"COLINK_HOME": colink_home},
-            cwd=working_dir,
-            stdout=DEVNULL,
-            stderr=DEVNULL,
+            cwd=working_dir
         )
         while True:
             if (

--- a/colink/instant_server.py
+++ b/colink/instant_server.py
@@ -71,7 +71,7 @@ class InstantServer:
                 "--inter-core-reverse-mode",
             ],
             env={"COLINK_HOME": colink_home},
-            cwd=working_dir
+            cwd=working_dir,
         )
         while True:
             if (
@@ -109,7 +109,8 @@ class InstantRegistry(InstantServer):
         super().clean()
         colink_home = get_colink_home()
         registry_file = os.path.join(colink_home, "reg_config")
-        os.remove(registry_file)
+        if os.path.exists(registry_file):
+            os.remove(registry_file)
 
 
 def get_colink_home() -> str:

--- a/colink/instant_server.py
+++ b/colink/instant_server.py
@@ -25,6 +25,7 @@ class InstantServer:
                     **os.environ,
                     "COLINK_INSTALL_SERVER_ONLY": "true",
                     "COLINK_INSTALL_SILENT": "true",
+                    "COLINK_SERVER_VERSION": "v0.2.9",
                 },
             ).wait()
         self.id = str(uuid.uuid4())

--- a/colink/p2p_inbox.py
+++ b/colink/p2p_inbox.py
@@ -138,9 +138,9 @@ class VtP2pCtx:
         self.remote_inboxes = remote_inboxs
 
 
-def _set_variable_p2p(cl, key: str, payload: bytes, receiver: CL.Participant):
+def _send_variable_p2p(cl, key: str, payload: bytes, receiver: CL.Participant):
     if not cl.vt_p2p_ctx.remote_inboxes.get(receiver.user_id, None):
-        inbox = cl.get_variable_with_remote_storage("inbox", receiver)
+        inbox = cl.recv_variable_with_remote_storage("inbox", receiver)
         vt_inbox_dic = json.loads(inbox)
         if isinstance(vt_inbox_dic["tls_cert"], list):
             vt_inbox_dic["tls_cert"] = bytes(vt_inbox_dic["tls_cert"])
@@ -178,7 +178,7 @@ def _set_variable_p2p(cl, key: str, payload: bytes, receiver: CL.Participant):
         raise Exception("Remote inbox: not available")
 
 
-def _get_variable_p2p(cl, key: str, sender: CL.Participant) -> bytes:
+def _recv_variable_p2p(cl, key: str, sender: CL.Participant) -> bytes:
     # send inbox information to the sender by remote_storage
     if not sender.user_id in cl.vt_p2p_ctx.has_configured_inbox:
         # create inbox if it does not exist
@@ -205,7 +205,7 @@ def _get_variable_p2p(cl, key: str, sender: CL.Participant) -> bytes:
                 "tls_cert": list(vt_inbox.tls_cert),
             }
         )
-        cl.set_variable_with_remote_storage(
+        cl.send_variable_with_remote_storage(
             "inbox", bytes(vt_inbox_vec, encoding="utf-8"), [sender]
         )
         cl.vt_p2p_ctx.has_configured_inbox.add(sender.user_id)

--- a/colink/variable_transfer.py
+++ b/colink/variable_transfer.py
@@ -2,16 +2,16 @@ import logging
 from typing import List, Any
 import colink as CL
 import threading
-from .p2p_inbox import _get_variable_p2p, _set_variable_p2p
+from .p2p_inbox import _recv_variable_p2p, _send_variable_p2p
 from .application import try_convert_to_bytes
 
 
-def set_variable_with_remote_storage(
+def send_variable_with_remote_storage(
     self, key: str, payload: bytes, receivers: List[CL.Participant]
 ):
     if self.task_id is None:
-        logging.error("set_variable task_id not found")
-        raise Exception("set_variable task_id not found")
+        logging.error("send_variable task_id not found")
+        raise Exception("send_variable task_id not found")
     new_participants = [CL.Participant(user_id=self.get_user_id(), role="requester")]
     for p in receivers:
         if p.user_id == self.get_user_id():
@@ -36,10 +36,10 @@ def set_variable_with_remote_storage(
     self.run_task("remote_storage.create", payload, new_participants, False)
 
 
-def get_variable_with_remote_storage(self, key: str, sender: CL.Participant) -> bytes:
+def recv_variable_with_remote_storage(self, key: str, sender: CL.Participant) -> bytes:
     if self.task_id is None:
-        logging.error("get_variable task_id not found")
-        raise Exception("get_variable task_id not found")
+        logging.error("recv_variable task_id not found")
+        raise Exception("recv_variable task_id not found")
     key = "_remote_storage:private:{}:_variable_transfer:{}:{}".format(
         sender.user_id, self.get_task_id(), key
     )
@@ -47,18 +47,18 @@ def get_variable_with_remote_storage(self, key: str, sender: CL.Participant) -> 
     return res
 
 
-def set_variable(self, key: str, payload: Any, receivers: List[CL.Participant]):
-    def thread_set_var(cl, key: str, payload: bytes, receiver: CL.Participant):
+def send_variable(self, key: str, payload: Any, receivers: List[CL.Participant]):
+    def thread_send_var(cl, key: str, payload: bytes, receiver: CL.Participant):
         try:
-            _set_variable_p2p(cl, key, payload, receiver)
+            _send_variable_p2p(cl, key, payload, receiver)
         except Exception as e:
-            cl.set_variable_with_remote_storage(key, payload, [receiver])
+            cl.send_variable_with_remote_storage(key, payload, [receiver])
 
     payload = try_convert_to_bytes(payload)
     threads = []
     for receiver in receivers:
         threads.append(
-            threading.Thread(target=thread_set_var, args=(self, key, payload, receiver))
+            threading.Thread(target=thread_send_var, args=(self, key, payload, receiver))
         )
     for th in threads:
         th.start()
@@ -66,11 +66,11 @@ def set_variable(self, key: str, payload: Any, receivers: List[CL.Participant]):
         th.join()
 
 
-def get_variable(self, key: str, sender: CL.Participant) -> bytes:
+def recv_variable(self, key: str, sender: CL.Participant) -> bytes:
     if self.task_id is None:
         raise Exception("task_id not found")
     try:
-        res = _get_variable_p2p(self, key, sender)
+        res = _recv_variable_p2p(self, key, sender)
     except Exception as e:
-        res = self.get_variable_with_remote_storage(key, sender)
+        res = self.recv_variable_with_remote_storage(key, sender)
     return res

--- a/download-server.sh
+++ b/download-server.sh
@@ -1,7 +1,7 @@
 set -e
 rm -rf colink-server
 mkdir colink-server && cd colink-server
-wget https://github.com/CoLearn-Dev/colink-server-dev/releases/download/v0.2.6/colink-server-linux-x86_64.tar.gz
+wget https://github.com/CoLearn-Dev/colink-server-dev/releases/download/v0.2.9/colink-server-linux-x86_64.tar.gz
 tar -xzf colink-server-linux-x86_64.tar.gz
 touch user_init_config.toml # create an empty user init config to prevent automatically starting protocols when importing users.
 cd ..

--- a/examples/protocol_greetings_with_init_func.py
+++ b/examples/protocol_greetings_with_init_func.py
@@ -14,13 +14,13 @@ def run_init(cl: CoLink, _param: bytes, _participants: List[CL.Participant]):
 @pop.handle("greetings:initiator")
 def run_initiator(cl: CoLink, param: bytes, participants: List[CL.Participant]):
     logging.info("greetings:initiator protocol operator!")
-    cl.set_variable("test:greeting:output", param, participants[1:])
+    cl.send_variable("test:greeting:output", param, participants[1:])
 
 
 @pop.handle("greetings:receiver")
 def run_receiver(cl: CoLink, param: bytes, participants: List[CL.Participant]):
     logging.info("greetings:receiver protocol operator!")
-    receive_data = cl.get_variable("test:greeting:output", participants[0])
+    receive_data = cl.recv_variable("test:greeting:output", participants[0])
     cl.create_entry("tasks:{}:output".format(cl.get_task_id()), receive_data)
 
 

--- a/examples/protocol_test_variable_transfer.py
+++ b/examples/protocol_test_variable_transfer.py
@@ -9,13 +9,13 @@ pop = ProtocolOperator(__name__)
 @pop.handle("test_variable_transfer:initiator")
 def run_initiator(cl: CoLink, param: bytes, participants: List[CL.Participant]):
     logging.info("test_variable_transfer:initiator protocol operator!")
-    cl.set_variable("output", param, participants[1:])
+    cl.send_variable("output", param, participants[1:])
 
 
 @pop.handle("test_variable_transfer:receiver")
 def run_receiver(cl: CoLink, param: bytes, participants: List[CL.Participant]):
     logging.info("test_variable_transfer:receiver protocol operator!")
-    receive_data = cl.get_variable("output", participants[0])
+    receive_data = cl.recv_variable("output", participants[0])
     cl.create_entry("tasks:{}:output".format(cl.get_task_id()), receive_data)
 
 

--- a/examples/user_policy_module.py
+++ b/examples/user_policy_module.py
@@ -16,7 +16,7 @@ if __name__ == "__main__":
     rule_id = cl.policy_module_add_rule(
         CL.Rule(
             task_filter=CL.TaskFilter(protocol_name="greetings"),
-            action="approve",
+            action=CL.Action(type="approve"),
             priority=1,
         )
     )

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ desc_file.close()
 
 setup(
     name="colink",
-    version="0.2.4",
+    version="0.2.5",
     description="colink python module",
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -62,6 +62,7 @@ setup(
         "secp256k1==0.14.0",
         "pika==1.2.0",
         "cryptography==38.0.3",
-        "pyjwt==2.6.0"
+        "pyjwt==2.6.0",
+        "requests==2.28.1"
     ],  # external packages as dependencies
 )

--- a/test/test_protocol_variable_transfer.py
+++ b/test/test_protocol_variable_transfer.py
@@ -11,8 +11,8 @@ def run_initiator(cl: CoLink, param: bytes, participants: List[CL.Participant]):
     for i in range(8):
         key = f"output{i}"
         key2 = f"output_remote_storage{i}"
-        cl.set_variable(key, param, participants[1 : len(participants)])
-        cl.set_variable_with_remote_storage(
+        cl.send_variable(key, param, participants[1 : len(participants)])
+        cl.send_variable_with_remote_storage(
             key2, param, participants[1 : len(participants)]
         )
 
@@ -22,9 +22,9 @@ def run_receiver(cl: CoLink, param: bytes, participants: List[CL.Participant]):
     for i in range(8):
         key = f"output{i}"
         key2 = f"output_remote_storage{i}"
-        msg = cl.get_variable(key, participants[0])
+        msg = cl.recv_variable(key, participants[0])
         cl.create_entry(f"tasks:{cl.get_task_id()}:output{i}", msg)
-        msg = cl.get_variable_with_remote_storage(key2, participants[0])
+        msg = cl.recv_variable_with_remote_storage(key2, participants[0])
         cl.create_entry(f"tasks:{cl.get_task_id()}:output_remote_storage{i}", msg)
 
 

--- a/test/test_user_management.py
+++ b/test/test_user_management.py
@@ -1,0 +1,51 @@
+from colink import (
+    CoLink,
+    InstantServer,
+    InstantRegistry,
+    prepare_import_user_signature,
+    decode_jwt_without_validation,
+    get_time_stamp,
+    generate_user,
+)
+
+
+def test_user_management():
+    _ir = InstantRegistry()
+    _is = InstantServer()
+    cl = _is.get_colink()
+    core_addr = cl.get_core_addr()
+    expiration_timestamp = get_time_stamp() + 86400 * 31
+    pk, sk = generate_user()
+    core_pub_key = cl.request_info().core_public_key
+    signature_timestamp, sig = prepare_import_user_signature(
+        pk, sk, core_pub_key, expiration_timestamp
+    )
+    user_jwt = cl.import_user(pk, signature_timestamp, expiration_timestamp, sig)
+    user_id = decode_jwt_without_validation(user_jwt).user_id
+    cl = CoLink(core_addr, user_jwt)
+    new_expiration_timestamp = get_time_stamp() + 86400 * 60
+    guest_jwt = cl.generate_token_with_expiration_time(
+        new_expiration_timestamp, "guest"
+    )
+    guest_auth_content = decode_jwt_without_validation(guest_jwt)
+    assert guest_auth_content.user_id == user_id
+    assert guest_auth_content.privilege == "guest"
+    assert guest_auth_content.exp == new_expiration_timestamp
+    cl = CoLink(core_addr, "")
+    new_signature_timestamp, new_sig = prepare_import_user_signature(
+        pk, sk, core_pub_key, new_expiration_timestamp
+    )
+    new_user_jwt = cl.generate_token_with_signature(
+        pk,
+        new_signature_timestamp,
+        new_expiration_timestamp,
+        new_sig,
+    )
+    user_auth_content = decode_jwt_without_validation(new_user_jwt)
+    assert user_auth_content.user_id == user_id
+    assert user_auth_content.privilege == "user"
+    assert user_auth_content.exp == new_expiration_timestamp
+
+
+if __name__ == "__main__":
+    test_user_management()


### PR DESCRIPTION
1. Rename set_variable, get_variable-> send_variable, recv_variable: https://github.com/CoLearn-Dev/colink-sdk-rust-dev/pull/55
2. Add generate_token_with_signature; add test_user_management: https://github.com/CoLearn-Dev/colink-sdk-rust-dev/pull/41
3. Instant server error redirect, check mq connection before start: https://github.com/CoLearn-Dev/colink-sdk-rust-dev/pull/40
4. Fix instant server version: https://github.com/CoLearn-Dev/colink-sdk-rust-dev/pull/51