### PR TITLE
Fix protocol operator multi-thread& vtinbox& read_or_wait issues

### DIFF
--- a/colink/p2p_inbox.py
+++ b/colink/p2p_inbox.py
@@ -128,14 +128,16 @@ class VtP2pCtx:
         public_addr: str = None,
         has_created_inbox: bool = False,
         inbox_server: VTInboxServer = None,
-        has_configured_inbox: Set[str] = set(),
-        remote_inboxs: Mapping[str, VTInbox] = {},
+        has_configured_inbox: Set[str] = None,
+        remote_inboxs: Mapping[str, VTInbox] = None,
     ):
         self.public_addr = public_addr
         self.has_created_inbox = has_created_inbox
         self.inbox_server = inbox_server
-        self.has_configured_inbox = has_configured_inbox
-        self.remote_inboxes = remote_inboxs
+        self.has_configured_inbox = (
+            has_configured_inbox if has_configured_inbox else set()
+        )
+        self.remote_inboxes = remote_inboxs if remote_inboxs else {}
 
 
 def _send_variable_p2p(cl, key: str, payload: bytes, receiver: CL.Participant):

--- a/colink/p2p_inbox.py
+++ b/colink/p2p_inbox.py
@@ -108,7 +108,7 @@ class VTInboxServer:
         )
         cert_file.close()
         priv_key_file.close()
-        self.server_thread = threading.Thread(target=httpd.serve_forever, args=())
+        self.server_thread = threading.Thread(target=httpd.serve_forever, args=(), daemon=True)
         httpd.thread = self.server_thread
         self.server_thread.start()
         self.port = port

--- a/colink/p2p_inbox.py
+++ b/colink/p2p_inbox.py
@@ -93,9 +93,9 @@ class VTInboxServer:
         cert_file.write(tls_cert_pem)
         cert_file.seek(0)
         # http server
-        port = random.randint(10000, 30000)
-        if socket.socket().connect_ex(("0.0.0.0", port)) == 0:
-            port = random.randint(10000, 30000)
+        port = random.randint(10000, 20000)
+        while socket.socket().connect_ex(("0.0.0.0", port)) == 0:
+            port = random.randint(10000, 20000)
         httpd = HTTPServer(("0.0.0.0", port), VTInBox_RequestHandler)
         httpd.data = dict()  # pass to http request handler
         httpd.notification_channels = dict()

--- a/colink/protocol.py
+++ b/colink/protocol.py
@@ -76,10 +76,9 @@ class ProtocolOperator:
         q = queue.Queue()
         for protocol_and_role in self.mapping.keys():  # insert user func to map
             user_func = self.mapping[protocol_and_role]
-            _cl = deepcopy(cl)
             t = threading.Thread(
                 target=thread_func,
-                args=(q, protocol_and_role, _cl, vt_public_addr, user_func),
+                args=(q, protocol_and_role, deepcopy(cl), vt_public_addr, user_func),
                 daemon=True,
             )
             threads.append(t)

--- a/colink/protocol.py
+++ b/colink/protocol.py
@@ -6,6 +6,7 @@ import queue
 import time
 import random
 import threading
+from copy import deepcopy
 from threading import Thread
 from .application import *
 from .p2p_inbox import VtP2pCtx
@@ -75,9 +76,10 @@ class ProtocolOperator:
         q = queue.Queue()
         for protocol_and_role in self.mapping.keys():  # insert user func to map
             user_func = self.mapping[protocol_and_role]
+            _cl = deepcopy(cl)
             t = threading.Thread(
                 target=thread_func,
-                args=(q, protocol_and_role, cl, vt_public_addr, user_func),
+                args=(q, protocol_and_role, _cl, vt_public_addr, user_func),
                 daemon=True,
             )
             threads.append(t)
@@ -195,7 +197,7 @@ class CoLinkProtocol:
                     task = Task.FromString(task_entry.payload)
                     if task.status == "started":
                         # begin user func
-                        cl = self.cl
+                        cl = deepcopy(self.cl)
                         cl.set_task_id(task.task_id)
                         cl.vt_p2p_ctx = VtP2pCtx(self.vt_public_addr)
                         try:

--- a/colink/read_wait.py
+++ b/colink/read_wait.py
@@ -7,7 +7,7 @@ def read_or_wait(self, key: str) -> bytes:
     if res is not None:
         return res
     else:
-        queue_name = self.subscribe(key, None)
+        queue_name = self.subscribe(key, 0)
         mut_subscriber = self.new_subscriber(queue_name)
         data = mut_subscriber.get_next()
         logging.info("Received [{}]".format(data))

--- a/colink/variable_transfer.py
+++ b/colink/variable_transfer.py
@@ -2,6 +2,7 @@ import logging
 from typing import List, Any
 import colink as CL
 from threading import Thread
+import logging
 from .p2p_inbox import _recv_variable_p2p, _send_variable_p2p
 from .application import try_convert_to_bytes
 

--- a/colink/variable_transfer.py
+++ b/colink/variable_transfer.py
@@ -58,12 +58,12 @@ def send_variable(self, key: str, payload: Any, receivers: List[CL.Participant])
     threads = []
     for receiver in receivers:
         threads.append(
-            threading.Thread(target=thread_send_var, args=(self, key, payload, receiver))
+            threading.Thread(
+                target=thread_send_var, args=(self, key, payload, receiver)
+            )
         )
     for th in threads:
         th.start()
-    for th in threads:
-        th.join()
 
 
 def recv_variable(self, key: str, sender: CL.Participant) -> bytes:

--- a/colink/variable_transfer.py
+++ b/colink/variable_transfer.py
@@ -48,7 +48,7 @@ def recv_variable_with_remote_storage(self, key: str, sender: CL.Participant) ->
 
 
 def send_variable(self, key: str, payload: Any, receivers: List[CL.Participant]):
-    def thr_send_var(cl, key: str, payload: bytes, receiver: CL.Participant):
+    def thd_send_var(cl, key: str, payload: bytes, receiver: CL.Participant):
         try:
             _send_variable_p2p(cl, key, payload, receiver)
         except Exception as e:
@@ -57,7 +57,7 @@ def send_variable(self, key: str, payload: Any, receivers: List[CL.Participant])
     payload = try_convert_to_bytes(payload)
     threads = []
     for receiver in receivers:
-        threads.append(Thread(target=thr_send_var, args=(self, key, payload, receiver)))
+        threads.append(Thread(target=thd_send_var, args=(self, key, payload, receiver)))
     for th in threads:
         th.start()
 

--- a/colink/variable_transfer.py
+++ b/colink/variable_transfer.py
@@ -1,7 +1,7 @@
 import logging
 from typing import List, Any
 import colink as CL
-import threading
+from threading import Thread
 from .p2p_inbox import _recv_variable_p2p, _send_variable_p2p
 from .application import try_convert_to_bytes
 
@@ -48,7 +48,7 @@ def recv_variable_with_remote_storage(self, key: str, sender: CL.Participant) ->
 
 
 def send_variable(self, key: str, payload: Any, receivers: List[CL.Participant]):
-    def thread_send_var(cl, key: str, payload: bytes, receiver: CL.Participant):
+    def thr_send_var(cl, key: str, payload: bytes, receiver: CL.Participant):
         try:
             _send_variable_p2p(cl, key, payload, receiver)
         except Exception as e:
@@ -57,11 +57,7 @@ def send_variable(self, key: str, payload: Any, receivers: List[CL.Participant])
     payload = try_convert_to_bytes(payload)
     threads = []
     for receiver in receivers:
-        threads.append(
-            threading.Thread(
-                target=thread_send_var, args=(self, key, payload, receiver)
-            )
-        )
+        threads.append(Thread(target=thr_send_var, args=(self, key, payload, receiver)))
     for th in threads:
         th.start()
 

--- a/colink/variable_transfer.py
+++ b/colink/variable_transfer.py
@@ -2,7 +2,6 @@ import logging
 from typing import List, Any
 import colink as CL
 from threading import Thread
-import logging
 from .p2p_inbox import _recv_variable_p2p, _send_variable_p2p
 from .application import try_convert_to_bytes
 

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ desc_file.close()
 
 setup(
     name="colink",
-    version="0.2.5",
+    version="0.2.6",
     description="colink python module",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
         grpc_tools_version,
         "secp256k1==0.14.0",
         "pika==1.2.0",
-        "cryptography==38.0.3",
+        "cryptography==39.0.1",
         "pyjwt==2.6.0",
         "requests==2.28.1"
     ],  # external packages as dependencies

--- a/test/test_python.py
+++ b/test/test_python.py
@@ -20,8 +20,6 @@ USER_NUM = [2, 2, 2, 2, 2, 3, 3, 4, 4, 5, 5]
 
 def run_greetings(port: int, user_num: int):
     try:
-        while socket.socket().connect_ex((CORE_ADDR, port)) == 0:
-            port = random.randint(port, port + 500)
         addr = "http://{}:{}".format(CORE_ADDR, port)
         child_processes = []
         thread_pool = concurrent.futures.ThreadPoolExecutor(max_workers=64)
@@ -187,7 +185,10 @@ def test_example_protocol_greetings():
         filename="test_example_protocol.log", filemode="a", level=logging.INFO
     )
     for i in range(0, 11):
-        run_greetings(12300 + i, USER_NUM[i])
+        port = 12300 + i
+        while socket.socket().connect_ex((CORE_ADDR, port)) == 0:
+            port = random.randint(port, port + 500)
+        run_greetings(port, USER_NUM[i])
 
 
 if __name__ == "__main__":

--- a/test/test_python.py
+++ b/test/test_python.py
@@ -20,14 +20,13 @@ USER_NUM = [2, 2, 2, 2, 2, 3, 3, 4, 4, 5, 5]
 
 def run_greetings(port: int, user_num: int):
     try:
+        while socket.socket().connect_ex((CORE_ADDR, port)) == 0:
+            port = random.randint(port, port + 500)
         addr = "http://{}:{}".format(CORE_ADDR, port)
         child_processes = []
         thread_pool = concurrent.futures.ThreadPoolExecutor(max_workers=64)
         threads = []
-        if socket.socket().connect_ex((CORE_ADDR, port)) == 0:
-            raise AssertionError(
-                "listen {}:{}: address already in use.".format(CORE_ADDR, port)
-            )
+
         if os.path.exists("./colink-server/host_token.txt"):
             os.remove("./colink-server/host_token.txt")
         child_processes.append(start_core(port, []))

--- a/test/test_python.py
+++ b/test/test_python.py
@@ -185,9 +185,9 @@ def test_example_protocol_greetings():
         filename="test_example_protocol.log", filemode="a", level=logging.INFO
     )
     for i in range(0, 11):
-        port = 12300 + i
+        port = random.randint(30000, 40000)
         while socket.socket().connect_ex((CORE_ADDR, port)) == 0:
-            port = random.randint(port, port + 500)
+            port = random.randint(30000, 40000)
         run_greetings(port, USER_NUM[i])
 
 

--- a/test/test_python.py
+++ b/test/test_python.py
@@ -26,7 +26,6 @@ def run_greetings(port: int, user_num: int):
         child_processes = []
         thread_pool = concurrent.futures.ThreadPoolExecutor(max_workers=64)
         threads = []
-
         if os.path.exists("./colink-server/host_token.txt"):
             os.remove("./colink-server/host_token.txt")
         child_processes.append(start_core(port, []))


### PR DESCRIPTION
1. Fix `send_variable` stuck problem, reported in https://gist.github.com/geos98/a11155cde8ecdf242ed34479dedf64a6#file-exchagne_error_twice-py
2. Fix failing to receive variable problem when running the task twice, reported in https://gist.github.com/geos98/a11155cde8ecdf242ed34479dedf64a6#file-exchange_error_concurrency-py
3. Adjust protocol operator implementation: protect colink class handler across threads with deep copy.
4. Solve `read_or_wait` implementation error, corrected subscription time to 0 instead of now, consistent with rust implementation: https://github.com/CoLearn-Dev/colink-sdk-rust-dev/blob/5c4ef2611e21dfe2d217e7e1bdfee9e5285a6335/src/extensions/read_or_wait.rs#L11.
5. Set vtinbox http-server thread as daemon, ensure graceful exit. 