### PR TITLE
Catch up with Rust SDK v0.3.0: MQ redis stream; fix CI timeout; throw error when no colink server

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -54,6 +54,7 @@ jobs:
           COLINK_SERVER_MQ_URI: ${{ matrix.mq_uri }}
           COLINK_SERVER_MQ_API: ${{ matrix.mq_api }}
         run: pytest test
+        timeout-minutes: 5
       - name: Run tests (standalone)
         if: ${{ matrix.mq == 'standalone' }}
         run: pytest test

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,12 +10,28 @@ jobs:
     defaults:
       run:
         shell: bash
+    strategy:
+      matrix:
+        mq: [standalone, rabbitmq, redis]
+        include:
+          - mq: rabbitmq
+            docker_image: "rabbitmq:3.8-management"
+            mq_uri: "amqp://guest:guest@localhost"
+            mq_api: "http://guest:guest@localhost:15672/api"
+          - mq: redis
+            docker_image: "redis"
+            mq_uri: "redis://localhost:16379"    
     services:
-      rabbitmq:
-        image: rabbitmq:3.8-management
+      mq:
+        image: ${{ matrix.docker_image }}
         ports:
-          - 5672:5672      
-          - 15672:15672
+          - 5672:5672   # rabbitmq
+          - 15672:15672 # rabbitmq
+          - 16379:6379  # redis
+      redis:  # for storage macro
+        image: redis
+        ports:
+          - 6379:6379
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -32,6 +48,13 @@ jobs:
         run: pip install  .
       - name: Install Pytest
         run: pip install pytest
-      - name: Run test
+      - name: Run tests
+        if: ${{ matrix.mq != 'standalone' }}
+        env:
+          COLINK_SERVER_MQ_URI: ${{ matrix.mq_uri }}
+          COLINK_SERVER_MQ_API: ${{ matrix.mq_api }}
+        run: pytest test
+      - name: Run tests (standalone)
+        if: ${{ matrix.mq == 'standalone' }}
         run: pytest test
         timeout-minutes: 5

--- a/colink/application.py
+++ b/colink/application.py
@@ -56,35 +56,32 @@ class CoLinkSubscriber:
 
     def get_next(self) -> bytes:
         if self.mq_type == "rabbitmq":
-            print("go rabbit ",self.queue_name)
+            #print("go rabbit ",self.queue_name)
             for method, _, body in self.rabbitmq_channel.consume(
                 self.queue_name
             ):  # get the first package from queue then return
                 self.rabbitmq_channel.basic_ack(
                     method.delivery_tag
                 )  # ack this package before return
-                print("acked")
-                print(body)
+                #print("acked")
+                #print(body)
                 return body
         elif self.mq_type == "redis":
             # data=self.redis_connection.get_message()
-            print("go redis",self.queue_name)
+            #print("go redis",self.queue_name)
             consumer_name = str(uuid.uuid4())
             res = self.redis_connection.xreadgroup(
                 self.queue_name, consumer_name, {self.queue_name: ">"}, count=1, block=0
             )
-            print("readed")
+            #print("readed")
             key, ids = res[0]
             id, _map = ids[0]
             data = _map[b"payload"]
             id = byte_to_str(id)
             self.redis_connection.xack(self.queue_name, self.queue_name, id)
-            print("acked ")
+            #print("acked ")
             #self.redis_connection.xdel(self.queue_name, id)
-            #print("del", file=open("1.txt", "a"))
-            print(data)
-
-            # p.subscribe('foo')
+            #print(data)
             return data
         else:
             raise Exception("Unsupported MQ type")

--- a/colink/application.py
+++ b/colink/application.py
@@ -56,33 +56,33 @@ class CoLinkSubscriber:
 
     def get_next(self) -> bytes:
         if self.mq_type == "rabbitmq":
-            print("go rabbit ",self.queue_name, file=open("1.txt", "a"))
+            print("go rabbit ",self.queue_name)
             for method, _, body in self.rabbitmq_channel.consume(
                 self.queue_name
             ):  # get the first package from queue then return
                 self.rabbitmq_channel.basic_ack(
                     method.delivery_tag
                 )  # ack this package before return
-                print("acked", file=open("1.txt", "a"))
-                print(body, file=open("1.txt", "a"))
+                print("acked")
+                print(body)
                 return body
         elif self.mq_type == "redis":
             # data=self.redis_connection.get_message()
-            print("go redis",self.queue_name, file=open("1.txt", "a"))
+            print("go redis",self.queue_name)
             consumer_name = str(uuid.uuid4())
             res = self.redis_connection.xreadgroup(
                 self.queue_name, consumer_name, {self.queue_name: ">"}, count=1, block=0
             )
-            print("readed", file=open("1.txt", "a"))
+            print("readed")
             key, ids = res[0]
             id, _map = ids[0]
             data = _map[b"payload"]
             id = byte_to_str(id)
             self.redis_connection.xack(self.queue_name, self.queue_name, id)
-            print("acked ", id, file=open("1.txt", "a"))
-            self.redis_connection.xdel(self.queue_name, id)
-            print("del", file=open("1.txt", "a"))
-            print(data, file=open("1.txt", "a"))
+            print("acked ")
+            #self.redis_connection.xdel(self.queue_name, id)
+            #print("del", file=open("1.txt", "a"))
+            print(data)
 
             # p.subscribe('foo')
             return data

--- a/colink/application.py
+++ b/colink/application.py
@@ -38,7 +38,7 @@ class CoLinkInfo:
 
 
 class CoLinkRedisSubscriber:
-    def __init__(self, queue_name, mq_uri):
+    def __init__(self, mq_uri, queue_name):
         self.queue_name = queue_name
         self.redis_connection = redis.from_url(mq_uri)
 
@@ -57,7 +57,7 @@ class CoLinkRedisSubscriber:
 
 
 class CoLinkRabbitMQSubscriber:
-    def __init__(self, queue_name, mq_uri):
+    def __init__(self, mq_uri, queue_name):
         self.queue_name = queue_name
         param = pika.connection.URLParameters(url=mq_uri)
         mq = pika.BlockingConnection(param)  # establish rabbitmq connection
@@ -76,9 +76,9 @@ class CoLinkRabbitMQSubscriber:
 def CoLinkSubscriber(mq_uri: str, queue_name: str):
     uri_parsed = urlparse(mq_uri)
     if uri_parsed.scheme.startswith("redis"):
-        return CoLinkRedisSubscriber(queue_name, mq_uri)
+        return CoLinkRedisSubscriber(mq_uri, queue_name)
     else:
-        return CoLinkRabbitMQSubscriber(queue_name, mq_uri)
+        return CoLinkRabbitMQSubscriber(mq_uri, queue_name)
 
 
 def request_info(self) -> CoLinkInfo:

--- a/colink/instant_server.py
+++ b/colink/instant_server.py
@@ -27,7 +27,7 @@ class InstantServer:
                     **os.environ,
                     "COLINK_INSTALL_SERVER_ONLY": "true",
                     "COLINK_INSTALL_SILENT": "true",
-                    "COLINK_SERVER_VERSION": "v0.3.0",
+                    "COLINK_SERVER_VERSION": "v0.3.3",
                 },
             ).wait()
         self.id = str(uuid.uuid4())

--- a/colink/p2p_inbox.py
+++ b/colink/p2p_inbox.py
@@ -93,9 +93,9 @@ class VTInboxServer:
         cert_file.write(tls_cert_pem)
         cert_file.seek(0)
         # http server
-        port = random.randint(10000, 30000)
-        if socket.socket().connect_ex(("0.0.0.0", port)) == 0:
-            port = random.randint(10000, 30000)
+        port = random.randint(10000, 20000)
+        while socket.socket().connect_ex(("0.0.0.0", port)) == 0:
+            port = random.randint(10000, 20000)
         httpd = HTTPServer(("0.0.0.0", port), VTInBox_RequestHandler)
         httpd.data = dict()  # pass to http request handler
         httpd.notification_channels = dict()

--- a/colink/protocol.py
+++ b/colink/protocol.py
@@ -6,6 +6,7 @@ import queue
 import time
 import random
 import threading
+import redis
 from copy import deepcopy
 from threading import Thread
 from .application import *
@@ -136,9 +137,11 @@ class CoLinkProtocol:
         self.user_func = user_func
 
     def start(self):
+        print('deq ',self.protocol_and_role,file=open('1.txt','a'))
         operator_mq_key = "_internal:protocols:{}:operator_mq".format(
             self.protocol_and_role
         )
+        lock = self.cl.lock(operator_mq_key)
         res = self.cl.read_entries(
             [
                 StorageEntry(
@@ -174,13 +177,11 @@ class CoLinkProtocol:
                         )
             queue_name = self.cl.subscribe(latest_key, start_timestamp)
             self.cl.create_entry(operator_mq_key, queue_name)
-        mq_addr = self.cl.request_info().mq_uri
-        param = pika.connection.URLParameters(url=mq_addr)
-        mq = pika.BlockingConnection(param)  # establish rabbitmq connection
-        channel = mq.channel()
-        for method, _, body in channel.consume(queue_name):
-            channel.basic_ack(method.delivery_tag)
-            data = body
+        self.cl.unlock(lock)
+        subscriber = self.cl.new_subscriber(queue_name)
+        while True:
+            print('get next! ',self.protocol_and_role,file=open('1.txt','a'))
+            data = subscriber.get_next()
             message = SubscriptionMessage.FromString(data)
             if message.change_type != "delete":
                 task_id = Task.FromString(message.payload)
@@ -200,6 +201,7 @@ class CoLinkProtocol:
                         cl.set_task_id(task.task_id)
                         cl.vt_p2p_ctx = VtP2pCtx(self.vt_public_addr)
                         try:
+                            print('run ',self.user_func,file=open('1.txt','a'))
                             self.user_func(cl, task.protocol_param, task.participants)
                         except Exception as e:
                             logging.info(
@@ -241,6 +243,10 @@ def _cl_parse_args() -> Tuple[CoLink, bool, str]:
         else os.environ.get("COLINK_VT_PUBLIC_ADDR", None)
     )
     cl = CoLink(addr, jwt)
+    try:
+        cl.request_info()
+    except Exception as e:
+        raise Exception("No CoLink Server found")
     if ca is not None:
         cl.ca_certificate(ca)
     if cert is not None and key is not None:

--- a/colink/protocol.py
+++ b/colink/protocol.py
@@ -137,7 +137,6 @@ class CoLinkProtocol:
         self.user_func = user_func
 
     def start(self):
-        print('deq ',self.protocol_and_role,file=open('1.txt','a'))
         operator_mq_key = "_internal:protocols:{}:operator_mq".format(
             self.protocol_and_role
         )
@@ -180,7 +179,6 @@ class CoLinkProtocol:
         self.cl.unlock(lock)
         subscriber = self.cl.new_subscriber(queue_name)
         while True:
-            print('get next! ',self.protocol_and_role,file=open('1.txt','a'))
             data = subscriber.get_next()
             message = SubscriptionMessage.FromString(data)
             if message.change_type != "delete":
@@ -201,7 +199,6 @@ class CoLinkProtocol:
                         cl.set_task_id(task.task_id)
                         cl.vt_p2p_ctx = VtP2pCtx(self.vt_public_addr)
                         try:
-                            print('run ',self.user_func,file=open('1.txt','a'))
                             self.user_func(cl, task.protocol_param, task.participants)
                         except Exception as e:
                             logging.info(

--- a/colink/protocol.py
+++ b/colink/protocol.py
@@ -16,7 +16,9 @@ from .colink import CoLink
 
 def thread_func(q, protocol_and_role, cl, vt_public_addr, attached, user_func):
     try:
-        cl_app = CoLinkProtocol(protocol_and_role, cl, vt_public_addr, attached, user_func)
+        cl_app = CoLinkProtocol(
+            protocol_and_role, cl, vt_public_addr, attached, user_func
+        )
         cl_app.start()
     except Exception as e:
         q.put(e)
@@ -38,7 +40,7 @@ class ProtocolOperator:
         cl: CoLink = None,
         keep_alive_when_disconnect: bool = False,
         vt_public_addr: str = None,
-        attached: bool = False
+        attached: bool = False,
     ):
         if cl is None:
             cl, keep_alive_when_disconnect, vt_public_addr = _cl_parse_args()
@@ -80,7 +82,14 @@ class ProtocolOperator:
             user_func = self.mapping[protocol_and_role]
             t = threading.Thread(
                 target=thread_func,
-                args=(q, protocol_and_role, deepcopy(cl), vt_public_addr, attached, user_func),
+                args=(
+                    q,
+                    protocol_and_role,
+                    deepcopy(cl),
+                    vt_public_addr,
+                    attached,
+                    user_func,
+                ),
                 daemon=True,
             )
             threads.append(t)
@@ -120,7 +129,9 @@ class ProtocolOperator:
                 time.sleep(0.01)
 
     def run_attach(self, cl: CoLink):
-        thread = Thread(target=self.run, args=(cl, False, "127.0.0.1", True), daemon=True)
+        thread = Thread(
+            target=self.run, args=(cl, False, "127.0.0.1", True), daemon=True
+        )
         thread.start()
 
 

--- a/colink/protocol.py
+++ b/colink/protocol.py
@@ -99,11 +99,7 @@ class ProtocolOperator:
                         break
                 else:
                     err = q.get()
-                    # in instance server and run_attach mode+standalone MQ, server closing MQ when shutdown may trigger this exception
-                    if attached and isinstance(err, redis.exceptions.ConnectionError):
-                        break
-                    else:
-                        raise err
+                    raise err
                 time.sleep(0.01)
         else:
             counter = 0

--- a/download-server.sh
+++ b/download-server.sh
@@ -1,7 +1,7 @@
 set -e
 rm -rf colink-server
 mkdir colink-server && cd colink-server
-wget https://github.com/CoLearn-Dev/colink-server-dev/releases/download/v0.2.9/colink-server-linux-x86_64.tar.gz
+wget https://github.com/CoLearn-Dev/colink-server-dev/releases/download/v0.3.0/colink-server-linux-x86_64.tar.gz
 tar -xzf colink-server-linux-x86_64.tar.gz
 touch user_init_config.toml # create an empty user init config to prevent automatically starting protocols when importing users.
 cd ..

--- a/download-server.sh
+++ b/download-server.sh
@@ -1,7 +1,7 @@
 set -e
 rm -rf colink-server
 mkdir colink-server && cd colink-server
-wget https://github.com/CoLearn-Dev/colink-server-dev/releases/download/v0.3.0/colink-server-linux-x86_64.tar.gz
+wget https://github.com/CoLearn-Dev/colink-server-dev/releases/download/v0.3.3/colink-server-linux-x86_64.tar.gz
 tar -xzf colink-server-linux-x86_64.tar.gz
 touch user_init_config.toml # create an empty user init config to prevent automatically starting protocols when importing users.
 cd ..

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ desc_file.close()
 
 setup(
     name="colink",
-    version="0.2.6",
+    version="0.3.0",
     description="colink python module",
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -63,6 +63,7 @@ setup(
         "pika==1.2.0",
         "cryptography==39.0.1",
         "pyjwt==2.6.0",
-        "requests==2.28.1"
+        "requests==2.28.1",
+        "redis==4.5.1"
     ],  # external packages as dependencies
 )

--- a/test/test_python.py
+++ b/test/test_python.py
@@ -185,9 +185,9 @@ def test_example_protocol_greetings():
         filename="test_example_protocol.log", filemode="a", level=logging.INFO
     )
     for i in range(0, 11):
-        port = random.randint(30000, 40000)
+        port = random.randint(10000, 20000)
         while socket.socket().connect_ex((CORE_ADDR, port)) == 0:
-            port = random.randint(30000, 40000)
+            port = random.randint(10000, 20000)
         run_greetings(port, USER_NUM[i])
 
 

--- a/test/test_python.py
+++ b/test/test_python.py
@@ -185,9 +185,9 @@ def test_example_protocol_greetings():
         filename="test_example_protocol.log", filemode="a", level=logging.INFO
     )
     for i in range(0, 11):
-        port = 12300 + i
+        port = random.randint(30000, 40000)
         while socket.socket().connect_ex((CORE_ADDR, port)) == 0:
-            port = random.randint(port, port + 500)
+            port = random.randint(30000, 40000)
         run_greetings(port, USER_NUM[i])
 
 


### PR DESCRIPTION
1. MQ alternative: redis stream: https://github.com/CoLearn-Dev/colink-sdk-rust-dev/pull/45
2. Fix CI test `test_python.py` time out by changing port number: https://github.com/CoLearn-Dev/colink-sdk-python-dev/issues/47
3. Fix MQ_API connection assert: https://github.com/CoLearn-Dev/colink-sdk-python-dev/issues/46
4. Throw error when no colink server: https://github.com/CoLearn-Dev/colink-sdk-python-dev/issues/44